### PR TITLE
token 만료 관련 로직 수정

### DIFF
--- a/src/Apis/@core.js
+++ b/src/Apis/@core.js
@@ -2,11 +2,25 @@ import axios from 'axios'
 import TokenService from '../Utils/tokenService'
 import UserApi from './userApi'
 import UserInfoService from '../Utils/userInfoService'
+import { COOKIE_KEY } from '../Consts/storage.key'
 
 const axiosInstance = axios.create({
 	baseURL: process.env.REACT_APP_BACKEND_URL,
 	withCredentials: true,
 })
+
+// 키로 쿠키 값을 찾는 함수
+const getCookieValue = cookieName => {
+	const cookies = document.cookie
+	const [cookie] = cookies
+		.split(';')
+		.map(cookie => cookie.trim())
+		.filter(cookie => cookie.startsWith(`${cookieName}=`))
+	if (cookie) {
+		return decodeURIComponent(cookie.split('=')[1])
+	}
+	return null
+}
 
 axiosInstance.interceptors.request.use(
 	config => {
@@ -31,29 +45,33 @@ axiosInstance.interceptors.response.use(
 			await UserApi.logout()
 			TokenService.removeAccessToken()
 		}
-		const originalRequest = error.config
-		if (
-			error.response.status === 403 &&
-			originalRequest.headers.Authorization &&
-			!originalRequest._retry
-		) {
-			originalRequest._retry = true
-			// refresh 관련 세션 만료
-			try {
-				const res = await UserApi.refreshToken()
-				if (res.status === 200) {
-					// access_token 다시 세팅
-					const { token } = res.data
-					TokenService.setAccessToken(token) // 새로운 access token 세팅
-					originalRequest.headers['Authorization'] = `bearer ${token}`
-					return axiosInstance(originalRequest) // 재요청
-				}
-			} catch (err) {
-				// refresh 토큰도 만료된 경우 로그아웃
+
+		if (error.response.status === 403) {
+			// refresh 토큰도 만료된 경우 로그아웃
+			await UserApi.logout()
+			TokenService.removeAccessToken()
+			UserInfoService.removeUserInfo()
+			return Promise.reject(error)
+		}
+
+		// access token 만료
+		if (error.response.status === 417 && !originalRequest._retry) {
+			originalRequest._retry = true // 재요청임을 표시
+
+			if (!getCookieValue(COOKIE_KEY.REFRESH_TOKEN)) {
+				// 쿠키에 refresh token이 없다면 === access token을 재발급 받지 못함 => 로그아웃 하고 바로 reject
 				await UserApi.logout()
 				TokenService.removeAccessToken()
 				UserInfoService.removeUserInfo()
+				return Promise.reject(error)
 			}
+
+			const res = await UserApi.refreshToken()
+			// access_token 다시 세팅
+			const { token } = res.data
+			TokenService.setAccessToken(token) // 새로운 access token 세팅
+			originalRequest.headers['Authorization'] = `bearer ${token}`
+			return axiosInstance(originalRequest) // 재요청
 		}
 		return Promise.reject(error)
 	},

--- a/src/Consts/storage.key.js
+++ b/src/Consts/storage.key.js
@@ -1,3 +1,7 @@
+export const COOKIE_KEY = {
+	REFRESH_TOKEN: 'dang',
+}
+
 const LOCAL_STORAGE_KEY = {
 	ACCESS_TOKEN: 'accessToken',
 	USER_INFO: 'userInfo',

--- a/src/Pages/Form/Login/Login.js
+++ b/src/Pages/Form/Login/Login.js
@@ -18,12 +18,11 @@ import AlertText from '../../../Components/AlertText/AlertText'
 
 import UserApi from '../../../Apis/userApi'
 import useUser from '../../../Hooks/useUser'
-import { useRecoilValue } from 'recoil'
-import { loginStateAtom } from '../../../Atoms/loginState.atom'
 import UserInfoService from '../../../Utils/userInfoService'
 import MESSAGE from '../../../Consts/message'
 import { useMutation } from '@tanstack/react-query'
 import { CircularProgress } from '@mui/material'
+import TokenService from '../../../Utils/tokenService'
 
 function Login() {
 	const navigate = useNavigate()
@@ -32,7 +31,7 @@ function Login() {
 
 	const [isSaveId, setIsSaveId] = useState(false)
 	const [error, setError] = useState(null)
-	const loginState = useRecoilValue(loginStateAtom)
+	const loginState = TokenService.getAccessToken()
 	const user = useUser()
 
 	const {


### PR DESCRIPTION
### refresh token이 만료되었을 경우 
  ==> cookie에 있는 refresh token으로 재발급 받아야 합니다.

1. cookie에 refresh token이 없는 경우 재발급 요청을 보내지 않고 바로 reject 합니다.
2. refresh token으로 재발급 요청을 보냈는데, 그 refresh token이 만료된 경우 로그아웃 후 reject 합니다.