### PR TITLE
🚑 Fix : 회원가입 - 주소, 연락처 관련 오류 수정

### DIFF
--- a/src/Components/DaumPostCodeAddress/DaumPostCodeAddress.js
+++ b/src/Components/DaumPostCodeAddress/DaumPostCodeAddress.js
@@ -26,17 +26,22 @@ function DaumPostCodeAddress({ setResultAddress, setLatAndLng }) {
 				Authorization: `KakaoAK ${process.env.REACT_APP_KAKAO_RESTAPI}`,
 			},
 		}
-		try {
-			const res = await axios(config)
-			if (res.data !== undefined || res.data !== null) {
-				if (res.data.documents[0].x && res.data.documents[0].y) {
-					setLatAndLng({
-						x: res.data.documents[0].x,
-						y: res.data.documents[0].y,
-					})
+
+		if (setLatAndLng) {
+			try {
+				const res = await axios(config)
+				if (res.data !== undefined || res.data !== null) {
+					if (res.data.documents[0].x && res.data.documents[0].y) {
+						setLatAndLng({
+							x: res.data.documents[0].x,
+							y: res.data.documents[0].y,
+						})
+					}
 				}
+			} catch (err) {
+				throw new Error('Daum Post code Error')
 			}
-		} catch (err) {}
+		}
 	}
 
 	return (

--- a/src/Components/Map/CoordinateToViewMap.js
+++ b/src/Components/Map/CoordinateToViewMap.js
@@ -1,0 +1,29 @@
+import { useEffect } from 'react'
+
+const { kakao } = window
+
+function CoordinateToViewMap({ LatAndLng, width, height }) {
+	useEffect(() => {
+		if (!LatAndLng) return
+
+		const { x, y } = LatAndLng
+		let mapContainer = document.getElementById('map')
+
+		let mapOption = {
+			center: new kakao.maps.LatLng(y, x),
+			level: 6,
+		}
+
+		const map = new kakao.maps.Map(mapContainer, mapOption)
+
+		const marker = new kakao.maps.Marker({
+			position: map.getCenter(),
+		})
+
+		marker.setMap(map)
+	}, [LatAndLng])
+
+	if (LatAndLng) return <div id="map" style={{ width, height }}></div>
+}
+
+export default CoordinateToViewMap

--- a/src/Components/Map/OrdinaryMap.js
+++ b/src/Components/Map/OrdinaryMap.js
@@ -1,0 +1,24 @@
+import React, { useEffect } from 'react'
+
+const { kakao } = window
+
+function OrdinaryMap({ LatAndLng, width, height }) {
+	if (!LatAndLng) return
+
+	const { x, y } = LatAndLng
+
+	useEffect(() => {
+		const container = document.getElementById('map')
+		const options = {
+			center: new kakao.maps.LatLng(x, y),
+			disableDoubleClickZoom: true, // 더블 클릭 금지
+			scrollwheel: false, // 스크롤 휠 금지
+			draggable: false, // 드래그 금지
+			zoomable: false, // 줌 버튼 비활성화
+		}
+		const kakaoMap = new kakao.maps.Map(container, options)
+	}, [LatAndLng])
+
+	return <div id="map" style={{ width, height }}></div>
+}
+export default OrdinaryMap

--- a/src/Pages/Form/SignUp/SignUp.js
+++ b/src/Pages/Form/SignUp/SignUp.js
@@ -18,6 +18,7 @@ import AlertModal from '../../../Components/Modal/AlertModal/AlertModal'
 import MESSAGE from '../../../Consts/message'
 import { useMutation } from '@tanstack/react-query'
 import { CircularProgress } from '@mui/material'
+import CoordinateToViewMap from '../../../Components/Map/CoordinateToViewMap'
 
 function SignUp() {
 	const navigate = useNavigate()
@@ -26,6 +27,7 @@ function SignUp() {
 		email: { state: null, message: '' },
 		nickname: { state: null, message: '' },
 	})
+	const [LatAndLng, setLatAndLng] = useState('') // 위도 경도
 	const [isOpenModal, setIsOpenModal] = useRecoilState(isOpenModalAtom)
 
 	const {
@@ -193,7 +195,10 @@ function SignUp() {
 							)}
 						></Controller>
 						{isOpenModal && modalType === 'region' && (
-							<RegionModal setRegion={setRegion} />
+							<RegionModal
+								setResultAddress={setRegion}
+								setLatAndLng={setLatAndLng}
+							/>
 						)}
 						<Controller
 							name="phone"
@@ -211,7 +216,13 @@ function SignUp() {
 							)}
 						></Controller>
 					</S.InputSection>
-					<S.MapSection></S.MapSection>
+					<S.MapSection>
+						<CoordinateToViewMap
+							LatAndLng={LatAndLng}
+							width={'100%'}
+							height={'100%'}
+						/>
+					</S.MapSection>
 				</div>
 				<div>
 					<Button>

--- a/src/Pages/Form/SignUp/SignUp.js
+++ b/src/Pages/Form/SignUp/SignUp.js
@@ -19,6 +19,7 @@ import MESSAGE from '../../../Consts/message'
 import { useMutation } from '@tanstack/react-query'
 import { CircularProgress } from '@mui/material'
 import CoordinateToViewMap from '../../../Components/Map/CoordinateToViewMap'
+import OrdinaryMap from '../../../Components/Map/OrdinaryMap'
 
 function SignUp() {
 	const navigate = useNavigate()
@@ -216,12 +217,20 @@ function SignUp() {
 							)}
 						></Controller>
 					</S.InputSection>
-					<S.MapSection>
-						<CoordinateToViewMap
-							LatAndLng={LatAndLng}
-							width={'100%'}
-							height={'100%'}
-						/>
+					<S.MapSection isVisible={LatAndLng}>
+						{LatAndLng ? (
+							<CoordinateToViewMap
+								LatAndLng={LatAndLng}
+								width={'100%'}
+								height={'100%'}
+							/>
+						) : (
+							<OrdinaryMap
+								LatAndLng={{ x: 33.450701, y: 126.570667 }}
+								width={'100%'}
+								height={'100%'}
+							/>
+						)}
 					</S.MapSection>
 				</div>
 				<div>
@@ -276,6 +285,7 @@ const MapSection = styled.section`
 	width: 49%;
 	height: 47.5rem;
 	background-color: gray;
+	opacity: ${({ isVisible }) => (isVisible ? 1 : 0.4)};
 
 	@media screen and (max-width: 670px) {
 		display: none;

--- a/src/Utils/addHyphenToPhoneNum.js
+++ b/src/Utils/addHyphenToPhoneNum.js
@@ -1,4 +1,6 @@
 const addHyphenToPhoneNum = str => {
+	if (!str) return
+
 	str = str.replace(/[^0-9]/g, '')
 	var tmp = ''
 	if (str.length < 4) {


### PR DESCRIPTION
### 회원가입 폼 내부에 이슈 수정

* RegionModal에 들어가는 주소를 set하는 함수를 전달하는 prop 이름이 안 맞아 주소가 set되지 않고 있던 문제 해결
* 연락처 input에 아무 것도 안 들어갔을 경우 Util 함수에서 return 처리

### 좌표 값으로 지도 띄우는 공용 컴포넌트 생성
* DaumPostCode에서 받은 위도 경도 값을 함께 전달해주면 맞게 지도가 띄워지도록