### PR TITLE
PC채팅 모달 오류 및 모바일 채팅방 UI 개선

### DIFF
--- a/src/Components/ChatModal/Components/Buyer/View/ChatBox/ChatBox.js
+++ b/src/Components/ChatModal/Components/Buyer/View/ChatBox/ChatBox.js
@@ -17,10 +17,7 @@ function BuyChatBox({ roomIdx }) {
 
 	// recoil 불러오기
 	const [myChatRoom, setMyChatRoom] = useRecoilState(myChatRoomList)
-
 	const [myInfo, setMyInfo] = useRecoilState(userInfoAtom)
-
-	const [chatState, setChatState] = useState(true)
 
 	//채팅방 리스트를 받아오고 room_idx와 동일한 채팅방 내역 불러오기
 	const chatInfo = myChatRoom.chats.find(item => item.idx === roomIdx)
@@ -61,9 +58,7 @@ function BuyChatBox({ roomIdx }) {
 		try {
 			const res = await ChatApi.chatRoomList()
 			setMyChatRoom(res.data)
-		} catch (err) {
-			throw err
-		}
+		} catch (err) {}
 	}
 
 	const getChatMsg = async () => {
@@ -71,9 +66,7 @@ function BuyChatBox({ roomIdx }) {
 		try {
 			const res = await ChatApi.checkChatLog(roomIdx)
 			setAllMessages(res.data)
-		} catch (error) {
-			throw err
-		}
+		} catch (error) {}
 	}
 
 	const postMessage = async e => {
@@ -103,9 +96,7 @@ function BuyChatBox({ roomIdx }) {
 					setSendMessages('')
 					newChatRoomList()
 				}
-			} catch (error) {
-				throw error
-			}
+			} catch (error) {}
 
 			return
 		}
@@ -115,20 +106,6 @@ function BuyChatBox({ roomIdx }) {
 		}
 	}
 
-	const onDisableChat = () => {
-		setChatState(false)
-	}
-	const exitChatRoom = () => {
-		if (window.confirm('정말 채팅방 나갈꺼에요?')) {
-			socket.emit('leave', { roomIdx })
-			onDisableChat()
-			// const lestChat = myChatRoom.chats.filter(item => item !== chatInfo)
-			// setMyChatRoom(lestChat)
-			// setAllMessages([])
-		} else {
-			return
-		}
-	}
 	useEffect(() => {
 		// 채팅방에 따른 메시지 내역 불러오기
 		getChatMsg()
@@ -142,35 +119,30 @@ function BuyChatBox({ roomIdx }) {
 	}, [socket])
 
 	return (
-		<S.ChatContainer chatState={chatState}>
+		<S.ChatContainer>
 			<S.ChatDate>
 				<span>{koreanDate}</span>
 
 				{/* 오늘 날짜로 */}
 			</S.ChatDate>
-			<S.ChatOption>
-				<span onClick={exitChatRoom}>채팅방 나가기</span>
-			</S.ChatOption>
+			<S.ChatOption></S.ChatOption>
 			<S.ChatMsg ref={scrollRef}>
 				{allMessages?.map((item, idx) => {
 					return <BuyMessagesBox key={idx} allMessages={item} myInfo={myInfo} />
 				})}
-				{!chatState && <h1>채팅방을 이용 할 수 없습니다.</h1>}
 			</S.ChatMsg>
 			<S.ChatSend onKeyDown={postMessage}>
 				<S.StyledInput
 					placeholder="메시지를 입력해주세요"
 					ref={messagesInput}
-					disabled={!chatState}
+
 					// value={sendMessages}
 					// onChange={e => {
 					// 	setSendMessages(e.target.value)
 					// }}
 				/>
 
-				<S.StyledButton onClick={postMessage} disabled={!chatState}>
-					전송
-				</S.StyledButton>
+				<S.StyledButton onClick={postMessage}>전송</S.StyledButton>
 			</S.ChatSend>
 		</S.ChatContainer>
 	)
@@ -187,8 +159,7 @@ const ChatContainer = styled.div`
 	box-shadow: 1px 1px 1px gray;
 	border-radius: 1rem;
 
-	background-color: ${({ theme, chatState }) =>
-		chatState ? theme.COLOR.common.gray[100] : theme.COLOR.common.gray[200]};
+	background-color: ${({ theme }) => theme.COLOR.common.gray[100]};
 `
 const ChatDate = styled.div`
 	margin-top: 2rem;

--- a/src/Components/ChatModal/Components/Seller/List/ItemBox/ItemBox.js
+++ b/src/Components/ChatModal/Components/Seller/List/ItemBox/ItemBox.js
@@ -20,7 +20,12 @@ function SellChatItemBox({ list }) {
 			<S.ImgBox images={list[0].product.img_url} />
 			<S.DesBox>
 				<p>{list[0].product.title}</p>
-				<p>{list[0].product.price}원</p>
+				<p>
+					{list[0].product.price
+						.toString()
+						.replace(/\B(?=(\d{3})+(?!\d))/g, ',')}
+					원
+				</p>
 				<p>최근 메시지 : {koreanDate}</p>
 			</S.DesBox>
 		</ItemContainer>

--- a/src/Components/ChatModal/Components/Seller/View/ChatBox/ChatBox.js
+++ b/src/Components/ChatModal/Components/Seller/View/ChatBox/ChatBox.js
@@ -17,8 +17,6 @@ function SellChatBox({ roomIdx, setViewChatState }) {
 	const [myChatRoom, setMyChatRoom] = useRecoilState(myChatRoomList)
 	const [myInfo, setMyInfo] = useRecoilState(userInfoAtom)
 
-	const [chatState, setChatState] = useState(true)
-
 	//채팅방 리스트를 받아오고 room_idx와 동일한 채팅방 내역 불러오기
 	const chatInfo = myChatRoom.chats.find(item => item.idx === roomIdx)
 	const [allMessages, setAllMessages] = useState([])
@@ -53,9 +51,7 @@ function SellChatBox({ roomIdx, setViewChatState }) {
 		try {
 			const res = await ChatApi.chatRoomList()
 			setMyChatRoom(res.data)
-		} catch (err) {
-			throw err
-		}
+		} catch (err) {}
 	}
 
 	const getChatMsg = async () => {
@@ -63,9 +59,7 @@ function SellChatBox({ roomIdx, setViewChatState }) {
 		try {
 			const res = await ChatApi.checkChatLog(roomIdx)
 			setAllMessages(res.data)
-		} catch (error) {
-			throw error
-		}
+		} catch (error) {}
 	}
 
 	const postMessage = async e => {
@@ -95,9 +89,7 @@ function SellChatBox({ roomIdx, setViewChatState }) {
 					setSendMessages('')
 					newChatRoomList()
 				}
-			} catch (error) {
-				throw error
-			}
+			} catch (error) {}
 
 			return
 		}
@@ -107,20 +99,6 @@ function SellChatBox({ roomIdx, setViewChatState }) {
 		}
 	}
 
-	const onDisableChat = () => {
-		setChatState(false)
-	}
-	const exitChatRoom = () => {
-		if (window.confirm('정말 채팅방 나갈꺼에요?')) {
-			socket.emit('leave', { roomIdx })
-			onDisableChat()
-			// const lestChat = myChatRoom.chats.filter(item => item !== chatInfo)
-			// setMyChatRoom(lestChat)
-			// setAllMessages([])
-		} else {
-			return
-		}
-	}
 	useEffect(() => {
 		// 채팅방에 따른 메시지 내역 불러오기
 		getChatMsg()
@@ -134,7 +112,7 @@ function SellChatBox({ roomIdx, setViewChatState }) {
 	}, [socket])
 
 	return (
-		<S.ChatContainer chatState={chatState}>
+		<S.ChatContainer>
 			<S.ChatDate>
 				<span>{koreanDate}</span>
 
@@ -148,7 +126,6 @@ function SellChatBox({ roomIdx, setViewChatState }) {
 				>
 					이전으로
 				</span>
-				<span onClick={exitChatRoom}>채팅방 나가기</span>
 			</S.ChatOption>
 			<S.ChatMsg ref={scrollRef}>
 				{allMessages?.map((item, idx) => {
@@ -156,22 +133,19 @@ function SellChatBox({ roomIdx, setViewChatState }) {
 						<SellMessagesBox key={idx} allMessages={item} myInfo={myInfo} />
 					)
 				})}
-				{!chatState && <h1>채팅방을 이용 할 수 없습니다.</h1>}
 			</S.ChatMsg>
 			<S.ChatSend onKeyDown={postMessage}>
 				<S.StyledInput
 					placeholder="메시지를 입력해주세요"
 					ref={messagesInput}
-					disabled={!chatState}
+
 					// value={sendMessages}
 					// onChange={e => {
 					// 	setSendMessages(e.target.value)
 					// }}
 				/>
 
-				<S.StyledButton onClick={postMessage} disabled={!chatState}>
-					전송
-				</S.StyledButton>
+				<S.StyledButton onClick={postMessage}>전송</S.StyledButton>
 			</S.ChatSend>
 		</S.ChatContainer>
 	)
@@ -188,8 +162,7 @@ const ChatContainer = styled.div`
 	box-shadow: 1px 1px 1px gray;
 	border-radius: 1rem;
 
-	background-color: ${({ theme, chatState }) =>
-		chatState ? theme.COLOR.common.gray[100] : theme.COLOR.common.gray[200]};
+	background-color: ${({ theme }) => theme.COLOR.common.gray[100]};
 `
 const ChatDate = styled.div`
 	margin-top: 2rem;

--- a/src/Components/ChatModal/Components/Seller/View/RoomBox/RoomBox.js
+++ b/src/Components/ChatModal/Components/Seller/View/RoomBox/RoomBox.js
@@ -5,9 +5,11 @@ import ChatApi from '../../../../../../Apis/chatApi'
 
 function SellRoomBox({ prod_idx, onClickUserChatRoom }) {
 	const prd_idx = prod_idx
+
 	const [productIdx, setProductIdx] = useState(prd_idx)
 	const [roomList, setRoomList] = useState([])
 	const [select, setSelect] = useState(null)
+
 	const options = {
 		timeZone: 'Asia/Seoul',
 		hour12: true, // 오후/오후 구분을 위해 true로 설정합니다.
@@ -16,20 +18,18 @@ function SellRoomBox({ prod_idx, onClickUserChatRoom }) {
 		hour: 'numeric',
 		minute: 'numeric',
 	}
-
 	const onClickSelect = id => {
 		setSelect(id)
 	}
-
 	//셀러냐 아니냐의 따라 또 달라지네...
+
 	const getChatRoomList = async () => {
 		if (productIdx !== null && productIdx !== undefined) {
 			try {
 				const res = await ChatApi.prdChatList(productIdx)
+
 				setRoomList(res.data)
-			} catch (error) {
-				throw error
-			}
+			} catch (error) {}
 		}
 	}
 	useEffect(() => {
@@ -79,8 +79,8 @@ const RoomBoxContainer = styled.div`
 const ProfileBox = styled.div`
 	display: flex;
 	width: 100%;
-	padding: 1rem 0.1rem;
 	margin-bottom: 0.5rem;
+	padding: 1rem 0.1rem;
 	height: 7rem;
 	border-radius: 1rem;
 	box-shadow: ${({ theme, roomId, selectId }) =>
@@ -88,7 +88,6 @@ const ProfileBox = styled.div`
 			? '2px 2px 1px 0px' + theme.COLOR.common.gray[200]
 			: ''};
 	:hover {
-		/* background-color: ${({ theme }) => theme.COLOR.common.gray[200]}; */
 		box-shadow: 2px 2px 1px 0px ${({ theme }) => theme.COLOR.common.gray[200]};
 	}
 `

--- a/src/Components/ChatModal/index.js
+++ b/src/Components/ChatModal/index.js
@@ -15,7 +15,6 @@ function ChatModal({ isDetailPage }) {
 	const socket = useSocket()
 	// 모달 HOOKS
 	const { chatModalOpen, closeChat } = useChatModal()
-	const [isSeller, setIsSeller] = useState(false)
 	// 채팅방 리스트 관리 recoil
 	const [roomList, setRoomList] = useRecoilState(myChatRoomList)
 	const [myInfo, setMyInfo] = useRecoilState(userInfoAtom)
@@ -52,10 +51,10 @@ function ChatModal({ isDetailPage }) {
 	const [viewChatIdx, setViewChatIdx] = useState(null)
 
 	// 판매자 시점 - 판매자가 등록한 물품리스트 중 물품의 채팅리스트
-	const onClickChatRoom = prod_idx => {
-		setViewChatIdx(prod_idx)
-		setViewChatState(true)
-	}
+	// const onClickChatRoom = prod_idx => {
+	// 	setViewChatIdx(prod_idx)
+	// 	setViewChatState(true)
+	// }
 
 	const preventScroll = () => {
 		const currentScrollY = window.scrollY

--- a/src/Components/Layout/Header/Components/UserBar.js
+++ b/src/Components/Layout/Header/Components/UserBar.js
@@ -35,7 +35,7 @@ function UserBar({ setSelectedNav }) {
 				<div
 					onClick={() => {
 						if (check) {
-							navigate('/chating')
+							navigate('/chat')
 						} else if (!check) {
 							openChat()
 						}

--- a/src/Components/Layout/Header/Header.js
+++ b/src/Components/Layout/Header/Header.js
@@ -71,7 +71,6 @@ function Header() {
 			className={scroll ? 'scroll' : ''}
 			chatModalOpen={chatModalOpen}
 		>
-			{chatModalOpen && <ChatModal isDetailPage={isDetailPage} />}
 			<Sidebar
 				onSideBar={onSideBar}
 				setOnSideBar={setOnSideBar}


### PR DESCRIPTION
1. 모바일 채팅창 전송 버튼 오류 해결 > 모바일은 엔터키 기능을 없애고 전송 버튼을 터치했을 시에만 채팅 전송
2. 채팅방 나가기 삭제 (PC/모바일 동일)
3. PC 채팅모달 진입 안됨 현상 해결 > try catch로 error를 잡고 있는데 catch문 안에 throw를 하고 있어서 오류 발생.(누가 throw 작성했는지 모르겠음...) 일단 throw 다 지웠습니다. 
4. isMobile()함수 추가로 모바일 이냐 pc냐 구분 짓게 해놨음. 
5. 모바일 채팅창 상단에 채팅 상대방 닉네임과 상품 정보 추가. 모바일 채팅방 리스트에서 내가 구매자 입장에서는 판매자의 프로필 사진을 받을 수 있지만 판매자 입장에서 구매자의 프로필 사진을 받을 수 없어서 채팅방 리스트에 유저 프로필 삭제함.